### PR TITLE
ssh-abbreviated-mode-default user-option controls abbreviation

### DIFF
--- a/ssh-file-modes.el
+++ b/ssh-file-modes.el
@@ -11,6 +11,8 @@
 ;; - using lexical binding
 ;; - add `ssh-abbreviated-mode-default' user-option
 ;; - `ssh-file-faces' is a child of `ssh-file' group.
+;; - modernize code: use `define-derived-mode' to define major modes
+;;   instead of `defun'
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -99,7 +101,7 @@ automatically."
 (defvar ssh-authorized-keys-mode-hook nil
   "*Hook to setup `ssh-authorized-keys-mode'.")
 
-(defvar ssh-authorized-keys-mode-font-lock-keywords
+(defconst ssh-authorized-keys-mode-font-lock-keywords
   (list
    `(,(regexp-opt '("cert-authority"
                     "command"
@@ -141,17 +143,17 @@ automatically."
   "Syntax table used by `ssh-authorized-keys-mode'.")
 
 ;;;###autoload
-(defun ssh-authorized-keys-mode ()
+(define-derived-mode ssh-authorized-keys-mode  nil "SSH[authorized_keys]"
   "Major mode for ssh authorized_keys files."
-  (interactive)
-  (kill-all-local-variables)
-  (setq major-mode 'ssh-known-hosts-mode
-        mode-name "SSH[authorized_keys]")
+
+  ;; Font locking control
+  (setq-local font-lock-defaults
+              '((ssh-authorized-keys-mode-font-lock-keywords)))
+
   (set-syntax-table ssh-authorized-keys-mode-syntax-table)
   (setq comment-start "#"
         comment-end "")
-  (setq font-lock-defaults
-        '(ssh-authorized-keys-mode-font-lock-keywords nil t))
+
   (setq truncate-lines t)
   (ssh-abbreviated-keys-mode (if ssh-abbreviated-mode-default 1 -1))
   (run-hooks 'ssh-authorized-keys-mode-hook))
@@ -163,7 +165,7 @@ automatically."
 (defvar ssh-known-hosts-mode-hook nil
   "*Hook to setup `ssh-known-hosts-mode'.")
 
-(defvar ssh-known-hosts-mode-font-lock-keywords
+(defconst ssh-known-hosts-mode-font-lock-keywords
   (list
    `(,(regexp-opt '("@cert-authority") 'words) . font-lock-keyword-face)
    `(,(regexp-opt '("@revoked") 'words) . font-lock-warning-face)
@@ -194,16 +196,15 @@ automatically."
   "Syntax table used by `ssh-known-hosts-mode'.")
 
 ;;;###autoload
-(defun ssh-known-hosts-mode ()
+(define-derived-mode ssh-known-hosts-mode nil "SSH[known_hosts]"
   "Major mode for ssh known_hosts files."
-  (interactive)
-  (kill-all-local-variables)
-  (setq major-mode 'ssh-known-hosts-mode
-        mode-name "SSH[known_hosts]")
+
+  ;; Font locking control
+  (setq-local font-lock-defaults '((ssh-known-hosts-mode-font-lock-keywords)))
+
   (set-syntax-table ssh-known-hosts-mode-syntax-table)
   (setq comment-start "#"
         comment-end "")
-  (setq font-lock-defaults '(ssh-known-hosts-mode-font-lock-keywords))
   (setq truncate-lines t)
   (ssh-abbreviated-keys-mode (if ssh-abbreviated-mode-default 1 -1))
   (run-hooks 'ssh-known-hosts-mode-hook))

--- a/ssh-file-modes.el
+++ b/ssh-file-modes.el
@@ -79,7 +79,10 @@ automatically."
   "Create overlay for making part of key invisible."
   (save-excursion
     (goto-char 1)
-    (while (re-search-forward  "\\<AAAA\\(?:\\s_\\|\\w\\)\\{8\\}\\(\\(?:\\s_\\|\\w\\)+\\)\\(?:\\s_\\|\\w\\)\\{8\\}" nil t)
+    (while
+        (re-search-forward
+         "\\<AAAA\\(?:\\s_\\|\\w\\)\\{8\\}\\(\\(?:\\s_\\|\\w\\)+\\)\\(?:\\s_\\|\\w\\)\\{8\\}"
+         nil t)
       (let ((ov (make-overlay (match-beginning 1) (match-end 1))))
         (overlay-put ov 'evaporate t)
         (overlay-put ov 'invisible 'ssh-file-key)))))
@@ -121,7 +124,8 @@ automatically."
                   'words)
      . 'ssh-file-key-type-face)
    '("\\<AAAA\\(?:\\s_\\|\\w\\)+" . 'ssh-file-key-face)
-   '("\\<AAAA\\(?:\\s_\\|\\w\\)+\\s-+\\(.+\\)$" . (1 font-lock-comment-face)) ;; trailing comment
+   ;; trailing comment
+   '("\\<AAAA\\(?:\\s_\\|\\w\\)+\\s-+\\(.+\\)$" . (1 font-lock-comment-face))
    ))
 
 (defvar ssh-authorized-keys-mode-syntax-table
@@ -146,13 +150,15 @@ automatically."
   (set-syntax-table ssh-authorized-keys-mode-syntax-table)
   (setq comment-start "#"
         comment-end "")
-  (setq font-lock-defaults '(ssh-authorized-keys-mode-font-lock-keywords nil t))
+  (setq font-lock-defaults
+        '(ssh-authorized-keys-mode-font-lock-keywords nil t))
   (setq truncate-lines t)
   (ssh-abbreviated-keys-mode (if ssh-abbreviated-mode-default 1 -1))
   (run-hooks 'ssh-authorized-keys-mode-hook))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '(".ssh/authorized_keys2?\\'" . ssh-authorized-keys-mode))
+(add-to-list 'auto-mode-alist
+             '(".ssh/authorized_keys2?\\'" . ssh-authorized-keys-mode))
 
 (defvar ssh-known-hosts-mode-hook nil
   "*Hook to setup `ssh-known-hosts-mode'.")
@@ -163,9 +169,13 @@ automatically."
    `(,(regexp-opt '("@revoked") 'words) . font-lock-warning-face)
    `(,(regexp-opt '("!")) . font-lock-negation-char-face)
    '("|\\S-+" . 'ssh-file-hashed-hostname-face)
-   '("^\\(?:\\s-*@[a-z-]+\\)?\\s-*\\S-+\\s-+\\(\\S-+\\)" . (1 'ssh-file-key-type-face))
-   '("^\\(?:\\s-*@[a-z-]+\\)?\\s-*\\S-+\\s-+\\S-+\\s-+\\(\\(?:\\s_\\|\\w\\)+\\)" . (1 'ssh-file-key-face))
-   '("^\\(?:\\s-*@[a-z-]+\\)?\\s-*\\S-+\\s-+\\S-+\\s-+\\(?:\\s_\\|\\w\\)+\\s-+\\(.+\\)$" . (1 font-lock-comment-face)))) ;; trailing comment
+   '("^\\(?:\\s-*@[a-z-]+\\)?\\s-*\\S-+\\s-+\\(\\S-+\\)"
+     . (1 'ssh-file-key-type-face))
+   '("^\\(?:\\s-*@[a-z-]+\\)?\\s-*\\S-+\\s-+\\S-+\\s-+\\(\\(?:\\s_\\|\\w\\)+\\)"
+     . (1 'ssh-file-key-face))
+   ;; trailing comment
+   '("^\\(?:\\s-*@[a-z-]+\\)?\\s-*\\S-+\\s-+\\S-+\\s-+\\(?:\\s_\\|\\w\\)+\\s-+\\(.+\\)$"
+     . (1 font-lock-comment-face))))
 
 (defvar ssh-known-hosts-mode-syntax-table
   (let ((table (make-syntax-table)))

--- a/ssh-file-modes.el
+++ b/ssh-file-modes.el
@@ -1,4 +1,4 @@
-;;; ssh-file-modes.el --- major modes for ssh authorized_keys and known_hosts files
+;;; ssh-file-modes.el --- major modes for ssh files -*-lexical-binding: t-*-
 
 ;; Copyright (C) 2015 Peter Eisentraut
 

--- a/ssh-file-modes.el
+++ b/ssh-file-modes.el
@@ -31,12 +31,24 @@
 ;; SSH keys invisible so that the content of the files fits better on
 ;; the screen.  It is enabled by default, but it can be turned off by
 ;; running `(ssh-abbreviated-keys-mode 0)'.
+;; If needed change the default by setting `ssh-abbreviated-mode-default'
+;; user-option to nil.
 
 ;;; Code:
 
 (defgroup ssh-file nil
   "Modes for editing SSH files"
   :group 'tools)
+
+(defcustom ssh-abbreviated-mode-default t
+  "Whether `ssh-abbreviated-mode' is activated automatically.
+
+Affects the initial behaviour of `ssh-authorized-keys-mode' and
+`ssh-known-hosts-mode'.  If set to `t', the long keys are abbreviated
+automatically."
+  :group 'ssh-file
+  :type 'boolean
+  :safe #'booleanp)
 
 (defgroup ssh-file-faces nil
   "Faces for highlighting SSH files"
@@ -70,7 +82,7 @@
 
 (define-minor-mode ssh-abbreviated-keys-mode
   "Minor mode that hides parts of lengthy SSH keys."
-  :init-value t
+  :init-value nil
   (if ssh-abbreviated-keys-mode
       (progn
         (ssh-abbreviated-keys-overlay)
@@ -93,13 +105,17 @@
                     "no-X11-forwarding"
                     "permitopen"
                     "principals"
-                    "tunnel") 'words) . font-lock-keyword-face)
+                    "tunnel")
+                  'words)
+     . font-lock-keyword-face)
    `(,(regexp-opt '("ecdsa-sha2-nistp256"
                     "ecdsa-sha2-nistp384"
                     "ecdsa-sha2-nistp521"
                     "ssh-ed25519"
                     "ssh-dss"
-                    "ssh-rsa") 'words) . 'ssh-file-key-type-face)
+                    "ssh-rsa")
+                  'words)
+     . 'ssh-file-key-type-face)
    '("\\<AAAA\\(?:\\s_\\|\\w\\)+" . 'ssh-file-key-face)
    '("\\<AAAA\\(?:\\s_\\|\\w\\)+\\s-+\\(.+\\)$" . (1 font-lock-comment-face)) ;; trailing comment
    ))
@@ -128,7 +144,7 @@
         comment-end "")
   (setq font-lock-defaults '(ssh-authorized-keys-mode-font-lock-keywords nil t))
   (setq truncate-lines t)
-  (ssh-abbreviated-keys-mode (symbol-value 'ssh-abbreviated-keys-mode))
+  (ssh-abbreviated-keys-mode (if ssh-abbreviated-mode-default 1 -1))
   (run-hooks 'ssh-authorized-keys-mode-hook))
 
 ;;;###autoload
@@ -175,7 +191,7 @@
         comment-end "")
   (setq font-lock-defaults '(ssh-known-hosts-mode-font-lock-keywords))
   (setq truncate-lines t)
-  (ssh-abbreviated-keys-mode (symbol-value 'ssh-abbreviated-keys-mode))
+  (ssh-abbreviated-keys-mode (if ssh-abbreviated-mode-default 1 -1))
   (run-hooks 'ssh-known-hosts-mode-hook))
 
 ;;;###autoload

--- a/ssh-file-modes.el
+++ b/ssh-file-modes.el
@@ -7,6 +7,11 @@
 ;; Version: 0
 ;; Keywords: languages
 
+;; Modifications: by Pierre Rouleau <prouleau001@gmail.com>
+;; - using lexical binding
+;; - add `ssh-abbreviated-mode-default' user-option
+;; - `ssh-file-faces' is a child of `ssh-file' group.
+
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation; either version 2 of the License, or
@@ -52,8 +57,7 @@ automatically."
 
 (defgroup ssh-file-faces nil
   "Faces for highlighting SSH files"
-  :prefix "ssh-file-"
-  :group 'ssh-file-
+  :group 'ssh-file
   :group 'faces)
 
 (defface ssh-file-hashed-hostname-face


### PR DESCRIPTION
In some cases, mainly when debugging ssh settings, I want to see the complete key in buffers I open.  The customization allows me to disable the minor mode activation for a while.

The default is still the same: abbreviation is activated automatically in both major modes.  However, it is now possible to change the default through customization.

And... thanks for this code!